### PR TITLE
DTSW-6923-update-dt-commons-to-new-dtps-http-version

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -25,7 +25,7 @@ coloredlogs<=15.0.1
 
 # -- Duckietown --
 
-dtps-http<=1.3.23
+git+https://github.com/duckietown/lib-dtps-http.git@v1.4.3#egg=dtps-http
 
 # messages
-duckietown-messages<=0.0.21
+duckietown-messages<1


### PR DESCRIPTION
## Description

Updating `dtps-http` to `v1.4.3`, providing a significant reduction of resources utilized.

Note: for this PR we have to install directly from the GitHub tag rather than PyPi while we sort out access to the PyPi project repo.