### PR TITLE
Add AbstractHardwareTest class and initialization logic for hardware tests

### DIFF
--- a/packages/dt_duckiebot_hardware_tests/__init__.py
+++ b/packages/dt_duckiebot_hardware_tests/__init__.py
@@ -1,0 +1,1 @@
+from .hardware_tests import AbstractHardwareTest

--- a/packages/dt_duckiebot_hardware_tests/hardware_tests.py
+++ b/packages/dt_duckiebot_hardware_tests/hardware_tests.py
@@ -1,0 +1,50 @@
+import time
+from abc import ABC, abstractmethod
+from typing import Any
+
+from dtps import DTPSContext
+from dtps_http import RawData
+from duckietown_messages.standard.dictionary import Dictionary
+from duckietown_messages.standard.header import Header
+
+
+class AbstractHardwareTest(ABC):
+    _node: Any
+    _test_out_queue: DTPSContext
+
+    def __init__(self, node: Any, test_out_queue: DTPSContext) -> None:
+        self._node = node
+        self._test_out_queue = test_out_queue
+        self.message = ""
+
+    @abstractmethod
+    async def run_test(self, dictionary: Dictionary) -> None:
+        """Run the test."""
+        pass
+
+    async def on_run_test(self, raw_data: RawData) -> None:
+        dictionary: Dictionary = Dictionary.from_rawdata(raw_data)
+        test_id = dictionary.data["test_id"]
+        self._node.loginfo(f"[{test_id}] Running test...")
+        try:
+            await self.run_test(dictionary)
+            success = True
+        except Exception as error:
+            self._node.logerr(f"Error running test: {error}")
+            success = False
+        data = {
+            "success": success,
+            "lst_blocks": [
+                {
+                    "key": "Test parameters",
+                    "type": "string",
+                    "value": self.message,
+                }
+            ]
+        }
+        timestamp = time.time()
+        header = Header(timestamp=timestamp)
+        dictionary = Dictionary(header=header, data=data)
+        raw_data = dictionary.to_rawdata()
+        await self._test_out_queue.publish(raw_data)
+        self._node.loginfo(f"[{test_id}] Test result sent...")


### PR DESCRIPTION
This pull request introduces a new abstract base class for hardware tests in the `dt_duckiebot_hardware_tests` package, designed to provide a consistent interface for running and reporting hardware tests. The main changes include the creation of the `AbstractHardwareTest` class and updating the package's initialization to expose this class.

### Hardware test framework improvements

* Added the `AbstractHardwareTest` abstract base class in `hardware_tests.py`, providing a standardized interface for running hardware tests asynchronously, handling test execution, error logging, and publishing results via a queue.
* Updated `__init__.py` to expose `AbstractHardwareTest` for import from the package.