### PR TITLE
Fix library installation and synchronize log levels for DEBUG mode

### DIFF
--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -303,7 +303,7 @@ configure_libraries() {
                             export POETRY_DYNAMIC_VERSIONING_BYPASS="0.0.0"
                             export POETRY_DYNAMIC_VERSIONING_COMMANDS=""
                             # install the library
-                            uv pip install --no-dependencies --editable "${TMP_LIB_DIR}/${LIB_NAME}" > /dev/null
+                            uv pip install --no-deps --editable "${TMP_LIB_DIR}/${LIB_NAME}" > /dev/null
                             info "  < Loaded library: ${LIB_NAME}\t(installed from temporary directory: ${TMP_LIB_DIR})"
                         fi
                         # ---

--- a/packages/dt_class_utils/process.py
+++ b/packages/dt_class_utils/process.py
@@ -40,6 +40,12 @@ class DTProcess(object):
             self._is_debug = True
         # install colored logs on our own logger
         install_colored_logs(logger=self.logger, level=self.logger.level)
+        # coloredlogs installs handlers with a fixed level — sync them to the logger's level
+        # so that DEBUG mode (set above or by a subclass) is not silently filtered by handlers
+        if self._is_debug:
+            for handler in logging.root.handlers + self.logger.handlers:
+                handler.setLevel(logging.DEBUG)
+            logging.root.setLevel(logging.DEBUG)
         # register signal handlers
         if self._catch_signals:
             signal.signal(signal.SIGINT, self._on_sigint)


### PR DESCRIPTION
This pull request includes improvements to logging behavior and a minor update to a dependency installation flag. The most significant change ensures that debug logging is consistently enabled when debug mode is active, preventing debug messages from being filtered by logging handlers.

Logging improvements:

* Updated the `__init__` method in `dt_class_utils/process.py` to synchronize the logging level of all handlers with the logger's level when debug mode is enabled, ensuring that debug messages are not filtered out.

Dependency installation:

* Changed the `uv pip install` command in `assets/entrypoint.sh` to use the `--no-deps` flag instead of `--no-dependencies` for installing libraries, aligning with the correct flag usage.