### PR TITLE
DTSW-7837 Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -1,5 +1,8 @@
 name: Enforce Jira Key in PR Title and Branch
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-commons/security/code-scanning/1](https://github.com/duckietown/dt-commons/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best single fix without changing behavior: set workflow-level permissions to read-only for repository contents, which is sufficient for this job since it only inspects event payload values and runs shell logic.

Change needed:
- **File:** `.github/workflows/jira-pr-check.yml`
- **Region:** directly below `name:` and before `on:`
- **Add:**
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
