### PR TITLE
DTSW-7935-Update-dtps-http-dependency-to-version-constraint-in-dt-commons

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -25,7 +25,7 @@ coloredlogs<=15.0.1
 
 # -- Duckietown --
 
-git+https://github.com/duckietown/lib-dtps-http.git@ente
+dtps-http<2
 
 # messages
 duckietown-messages<1


### PR DESCRIPTION
This pull request updates the dependency specification for `dtps-http` in `dependencies-py3.txt`, switching from a GitHub source to a PyPI version constraint. This change helps standardize dependency management and ensures compatibility with versions below 2.

Dependency management:

* Updated the `dtps-http` dependency from a GitHub repository reference to a PyPI version constraint (`dtps-http<2`) in `dependencies-py3.txt`, improving package management and version control.